### PR TITLE
added record status to handle entity visibility and soft deletion

### DIFF
--- a/src/main/java/com/gbroche/courseorganizer/controller/GenreController.java
+++ b/src/main/java/com/gbroche/courseorganizer/controller/GenreController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Genre;
 import com.gbroche.courseorganizer.repository.GenreRepository;
 
@@ -41,7 +43,7 @@ public class GenreController {
 
     @PostMapping
     public Genre create(@RequestBody Genre genre) {
-        return repository.save(genre);
+        return repository.saveAndFlush(genre);
     }
 
     @PutMapping("/{id}")
@@ -49,12 +51,24 @@ public class GenreController {
         try {
             Genre existing = repository.findById(id).orElseThrow();
             existing.setLabel(genre.getLabel());
-            Genre edited = repository.save(existing);
+            Genre edited = repository.saveAndFlush(existing);
             return ResponseEntity.ok(edited);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("No corresponding entity found");
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Failed to update entity");
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> softDeleteById(@PathVariable Long id) {
+        try {
+            Genre genreToSoftDelete = repository.findById(id).orElseThrow();
+            genreToSoftDelete.setRecordStatus(RecordStatus.TO_DELETE);
+            repository.saveAndFlush(genreToSoftDelete);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body("No corresponding entity found");
         }
     }
 }

--- a/src/main/java/com/gbroche/courseorganizer/controller/RoleController.java
+++ b/src/main/java/com/gbroche/courseorganizer/controller/RoleController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Role;
 import com.gbroche.courseorganizer.repository.RoleRepository;
 
@@ -41,7 +43,7 @@ public class RoleController {
 
     @PostMapping
     public Role create(@RequestBody Role role) {
-        return repository.save(role);
+        return repository.saveAndFlush(role);
     }
 
     @PutMapping("/{id}")
@@ -49,12 +51,24 @@ public class RoleController {
         try {
             Role existing = repository.findById(id).orElseThrow();
             existing.setLabel(role.getLabel());
-            Role editedRole = repository.save(existing);
+            Role editedRole = repository.saveAndFlush(existing);
             return ResponseEntity.ok(editedRole);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("No corresponding entity found");
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Failed to update entity");
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> softDeleteById(@PathVariable Long id) {
+        try {
+            Role roleToSoftDelete = repository.findById(id).orElseThrow();
+            roleToSoftDelete.setRecordStatus(RecordStatus.TO_DELETE);
+            repository.saveAndFlush(roleToSoftDelete);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body("No corresponding entity found");
         }
     }
 }

--- a/src/main/java/com/gbroche/courseorganizer/controller/SkillController.java
+++ b/src/main/java/com/gbroche/courseorganizer/controller/SkillController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Skill;
 import com.gbroche.courseorganizer.repository.SkillRepository;
 
@@ -53,7 +55,7 @@ public class SkillController {
     @PostMapping
     public Skill create(@RequestBody Skill skill) {
         skill.setCreatedAt(LocalDateTime.now());
-        return repository.save(skill);
+        return repository.saveAndFlush(skill);
     }
 
     @PutMapping("/{id}")
@@ -63,12 +65,24 @@ public class SkillController {
             found.setLabel(skill.getLabel());
             found.setIsHardSkill(skill.isHardSkill());
             found.setUpdatedAt(LocalDateTime.now());
-            Skill editedSkill = repository.save(found);
+            Skill editedSkill = repository.saveAndFlush(found);
             return ResponseEntity.ok(editedSkill);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("No corresponding entity found");
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Failed to update entity");
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> softDeleteById(@PathVariable Long id) {
+        try {
+            Skill toSoftDelete = repository.findById(id).orElseThrow();
+            toSoftDelete.setRecordStatus(RecordStatus.TO_DELETE);
+            repository.saveAndFlush(toSoftDelete);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body("No corresponding entity found");
         }
     }
 }

--- a/src/main/java/com/gbroche/courseorganizer/controller/StatusController.java
+++ b/src/main/java/com/gbroche/courseorganizer/controller/StatusController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Status;
 import com.gbroche.courseorganizer.repository.StatusRepository;
 
@@ -41,7 +43,7 @@ public class StatusController {
 
     @PostMapping
     public Status create(@RequestBody Status status) {
-        return repository.save(status);
+        return repository.saveAndFlush(status);
     }
 
     @PutMapping("/{id}")
@@ -49,12 +51,25 @@ public class StatusController {
         try {
             Status existing = repository.findById(id).orElseThrow();
             existing.setLabel(status.getLabel());
-            Status editedStatus = repository.save(existing);
+            Status editedStatus = repository.saveAndFlush(existing);
             return ResponseEntity.ok(editedStatus);
         } catch (NoSuchElementException e) {
             return ResponseEntity.status(404).body("No corresponding entity found");
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body("Failed to update entity");
+        }
+
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> softDeleteById(@PathVariable Long id) {
+        try {
+            Status toSoftDelete = repository.findById(id).orElseThrow();
+            toSoftDelete.setRecordStatus(RecordStatus.TO_DELETE);
+            repository.saveAndFlush(toSoftDelete);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(404).body("No corresponding entity found");
         }
     }
 }

--- a/src/main/java/com/gbroche/courseorganizer/enums/RecordStatus.java
+++ b/src/main/java/com/gbroche/courseorganizer/enums/RecordStatus.java
@@ -1,0 +1,7 @@
+package com.gbroche.courseorganizer.enums;
+
+public enum RecordStatus {
+    SHOWN,
+    HIDDEN,
+    TO_DELETE
+}

--- a/src/main/java/com/gbroche/courseorganizer/interfaces/RecordStatusTrackable.java
+++ b/src/main/java/com/gbroche/courseorganizer/interfaces/RecordStatusTrackable.java
@@ -1,0 +1,9 @@
+package com.gbroche.courseorganizer.interfaces;
+
+import com.gbroche.courseorganizer.enums.RecordStatus;
+
+public interface RecordStatusTrackable {
+    RecordStatus getRecordStatus();
+
+    void setRecordStatus(RecordStatus status);
+}

--- a/src/main/java/com/gbroche/courseorganizer/model/Genre.java
+++ b/src/main/java/com/gbroche/courseorganizer/model/Genre.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-public class Genre {
+public class Genre extends RecordStatusEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gbroche/courseorganizer/model/RecordStatusEntity.java
+++ b/src/main/java/com/gbroche/courseorganizer/model/RecordStatusEntity.java
@@ -1,0 +1,24 @@
+package com.gbroche.courseorganizer.model;
+
+import com.gbroche.courseorganizer.enums.RecordStatus;
+import com.gbroche.courseorganizer.interfaces.RecordStatusTrackable;
+
+import jakarta.persistence.*;
+
+@MappedSuperclass
+public abstract class RecordStatusEntity implements RecordStatusTrackable {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RecordStatus recordStatus = RecordStatus.SHOWN;
+
+    @Override
+    public RecordStatus getRecordStatus() {
+        return recordStatus;
+    }
+
+    @Override
+    public void setRecordStatus(RecordStatus status) {
+        this.recordStatus = status;
+    }
+}

--- a/src/main/java/com/gbroche/courseorganizer/model/Role.java
+++ b/src/main/java/com/gbroche/courseorganizer/model/Role.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-public class Role {
+public class Role extends RecordStatusEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gbroche/courseorganizer/model/Skill.java
+++ b/src/main/java/com/gbroche/courseorganizer/model/Skill.java
@@ -9,7 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-public class Skill {
+public class Skill extends RecordStatusEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gbroche/courseorganizer/model/Status.java
+++ b/src/main/java/com/gbroche/courseorganizer/model/Status.java
@@ -7,7 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
-public class Status {
+public class Status extends RecordStatusEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/gbroche/courseorganizer/repository/GenreRepository.java
+++ b/src/main/java/com/gbroche/courseorganizer/repository/GenreRepository.java
@@ -1,9 +1,6 @@
 package com.gbroche.courseorganizer.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.gbroche.courseorganizer.model.Genre;
 
-public interface GenreRepository extends JpaRepository<Genre, Long> {
-
+public interface GenreRepository extends RecordStatusRepository<Genre, Long> {
 }

--- a/src/main/java/com/gbroche/courseorganizer/repository/RecordStatusRepository.java
+++ b/src/main/java/com/gbroche/courseorganizer/repository/RecordStatusRepository.java
@@ -1,0 +1,20 @@
+package com.gbroche.courseorganizer.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import com.gbroche.courseorganizer.enums.RecordStatus;
+import com.gbroche.courseorganizer.interfaces.RecordStatusTrackable;
+
+@NoRepositoryBean
+public interface RecordStatusRepository<T extends RecordStatusTrackable, ID>
+        extends JpaRepository<T, ID> {
+
+    List<T> findByRecordStatus(RecordStatus status);
+
+    List<T> findByRecordStatusNot(RecordStatus status);
+
+    List<T> findByRecordStatusNotIn(RecordStatus[] statuses);
+}

--- a/src/test/java/com/gbroche/courseorganizer/controller/GenreControllerTest.java
+++ b/src/test/java/com/gbroche/courseorganizer/controller/GenreControllerTest.java
@@ -9,10 +9,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Genre;
 import com.gbroche.courseorganizer.repository.GenreRepository;
 
@@ -41,7 +43,8 @@ public class GenreControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(toAdd)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.label").value("Male"));
+                .andExpect(jsonPath("$.label").value("Male"))
+                .andExpect(jsonPath("$.recordStatus").value("SHOWN"));
     }
 
     @Test
@@ -78,5 +81,14 @@ public class GenreControllerTest {
                 .content(objectMapper.writeValueAsString(toEdit)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.label").value("Male"));
+    }
+
+    @Test
+    void testSoftDeleteById_GivenValidId_ChangesRecordStatus() throws Exception {
+        Genre toDelete = repository.save(new Genre("delete test"));
+        mockMvc.perform(delete("/api/genres/" + toDelete.getId()))
+                .andExpect(status().isNoContent());
+        Genre softDeletedGenre = repository.findById(toDelete.getId()).orElseThrow();
+        assertEquals(RecordStatus.TO_DELETE, softDeletedGenre.getRecordStatus());
     }
 }

--- a/src/test/java/com/gbroche/courseorganizer/controller/SkillControllerTest.java
+++ b/src/test/java/com/gbroche/courseorganizer/controller/SkillControllerTest.java
@@ -9,12 +9,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Skill;
 import com.gbroche.courseorganizer.repository.SkillRepository;
 
@@ -45,7 +47,8 @@ public class SkillControllerTest {
                 .content(objectMapper.writeValueAsString(toAdd)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.label").value("Curious"))
-                .andExpect(jsonPath("$.hardSkill").value(false));
+                .andExpect(jsonPath("$.hardSkill").value(false))
+                .andExpect(jsonPath("$.recordStatus").value("SHOWN"));
     }
 
     @Test
@@ -103,5 +106,14 @@ public class SkillControllerTest {
                 .content(objectMapper.writeValueAsString(toEdit)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.label").value("Curious"));
+    }
+
+    @Test
+    void testSoftDeleteById_GivenValidId_ChangesRecordStatus() throws Exception {
+        Skill toDelete = repository.save(new Skill("delete test", false, LocalDateTime.now()));
+        mockMvc.perform(delete("/api/skills/" + toDelete.getId()))
+                .andExpect(status().isNoContent());
+        Skill softDeleted = repository.findById(toDelete.getId()).orElseThrow();
+        assertEquals(RecordStatus.TO_DELETE, softDeleted.getRecordStatus());
     }
 }

--- a/src/test/java/com/gbroche/courseorganizer/controller/StatusControllerTest.java
+++ b/src/test/java/com/gbroche/courseorganizer/controller/StatusControllerTest.java
@@ -9,11 +9,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gbroche.courseorganizer.model.Role;
+import com.gbroche.courseorganizer.enums.RecordStatus;
 import com.gbroche.courseorganizer.model.Status;
 import com.gbroche.courseorganizer.repository.StatusRepository;
 
@@ -43,7 +44,8 @@ public class StatusControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(ToAdd)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.label").value("Ongoing"));
+                .andExpect(jsonPath("$.label").value("Ongoing"))
+                .andExpect(jsonPath("$.recordStatus").value("SHOWN"));
     }
 
     @Test
@@ -80,5 +82,14 @@ public class StatusControllerTest {
                 .content(objectMapper.writeValueAsString(toEdit)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.label").value("Ongoing"));
+    }
+
+    @Test
+    void testSoftDeleteById_GivenValidId_ChangesRecordStatus() throws Exception {
+        Status toDelete = repository.save(new Status("delete test"));
+        mockMvc.perform(delete("/api/status/" + toDelete.getId()))
+                .andExpect(status().isNoContent());
+        Status softDeleted = repository.findById(toDelete.getId()).orElseThrow();
+        assertEquals(RecordStatus.TO_DELETE, softDeleted.getRecordStatus());
     }
 }


### PR DESCRIPTION
Implemented handling of database record visibility and soft deletion.

Created entity parent superclass with RecordStatus property and the related enum with <SHOWN>, <HIDDEN> and <TO_DELETE>. Added a parent repository class to expose methods for repositories managing entities with the RecordStatus management.

On delete request will perform soft deletion by changing the record status property of the entity to "TO_DELETE".